### PR TITLE
[List] 리스트 카드 및 슬라이더 UI 구현

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,16 +1,4 @@
 {
-  "printWidth": 80,
   "tabWidth": 2,
-  "useTabs": false,
-  "semi": true,
-  "singleQuote": true,
-  "quoteProps": "as-needed",
-  "jsxSingleQuote": true,
-  "trailingComma": "es5",
-  "bracketSpacing": true,
-  "bracketSameLine": false,
-  "arrowParens": "always",
-  "endOfLine": "lf",
-  "proseWrap": "always",
-  "htmlWhitespaceSensitivity": "strict"
+  "useTabs": false
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,28 +1,10 @@
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
 
-import MainLayout from '@/layouts/MainLayout';
-import PostPageLayout from '@/layouts/PostPageLayout';
-import Home from '@/pages/Home';
-import NotFound from '@/pages/NotFound';
+import Home from "@/pages/Home";
 
-createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route element={<MainLayout />}>
-          <Route path='/' element={<Home />} />
-          <Route path='/list' element={<NotFound />} />
-          <Route path='/post' element={<NotFound />} />
-          <Route path='/post/:id/message' element={<NotFound />} />
-        </Route>
-        <Route element={<PostPageLayout />}>
-          <Route path='/post/:id' element={<NotFound />} />
-          <Route path='/post/:id/edit' element={<NotFound />} />
-          <Route path='*' element={<NotFound />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
-  </StrictMode>
+    <Home />
+  </StrictMode>,
 );

--- a/src/pages/list/CardItem.jsx
+++ b/src/pages/list/CardItem.jsx
@@ -1,0 +1,55 @@
+import styles from "@/pages/list/CardItem.module.scss";
+
+function CardItem({
+  title,
+  participants = [],
+  totalCount,
+  emojiReaction = [],
+  backgroundImage,
+  backgroundColor,
+}) {
+  return (
+    <div
+      className={styles.card}
+      style={{
+        backgroundImage: backgroundImage ? `url(${backgroundImage})` : "none",
+        backgroundColor: backgroundImage ? undefined : backgroundColor,
+      }}
+    >
+      {/* 단일 카드 구성 요소 */}
+      <div className={styles.thumbnail}>
+        <h3 className={styles.title}>To. {title}</h3>
+        {/* 참여자 리스트 */}
+        <div className={styles.participants}>
+          {participants.slice(0, 3).map((url, index) => (
+            <img
+              key={index}
+              src={url}
+              alt={`participant-${index}`}
+              className={styles.avatar}
+            />
+          ))}
+          {participants.length > 3 && (
+            <span className={styles.extra}>+{participants.length - 3}</span>
+          )}
+        </div>
+
+        <p className={styles.count}>
+          <span className={styles.total}>{totalCount}</span>명이 작성했어요!
+        </p>
+      </div>
+      <hr className={styles.divider} />
+
+      <div className={styles.reactions}>
+        {emojiReaction.map((reaction, idx) => (
+          <div key={idx} className={styles.reaction}>
+            <span>{reaction.emoji}</span>
+            <span>{reaction.count}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default CardItem;

--- a/src/pages/list/CardItem.module.scss
+++ b/src/pages/list/CardItem.module.scss
@@ -1,0 +1,115 @@
+@use "@/styles/token" as token;
+
+.card {
+  width: 275px;
+  height: 260px;
+  border-radius: token.$size-md;
+  overflow: visible;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  //현재 색상 기본값
+  background-color: token.$white;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  //호버시 효과
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+  will-change: transform;
+  &:hover {
+    transform: scale(1.03); // 약간 확대
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15); // 떠오르는 느낌
+  }
+}
+
+.thumbnail {
+  height: 210px;
+  padding: 30px 24px 20px;
+  background-size: cover;
+  background-position: center;
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  overflow: visible;
+}
+
+.title {
+  font-size: token.$font-2xl;
+  font-weight: 700;
+  color: token.$gray900;
+}
+
+.participants {
+  display: flex;
+  align-items: center;
+
+  & > * {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 1.5px solid token.$white;
+    object-fit: cover;
+    margin-left: -12px;
+
+    &:first-child {
+      margin-left: 0;
+    }
+  }
+}
+
+.extra {
+  background-color: token.$white;
+  color: token.$gray500;
+  font-size: token.$font-xs;
+  font-weight: 400;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 33px;
+  height: 28px;
+  border-radius: 30px;
+  margin-left: -12px;
+}
+
+.count {
+  font-size: token.$font-md;
+  font-weight: 400;
+  color: token.$gray700;
+}
+
+.total {
+  font-size: token.$font-md;
+  font-weight: 700;
+  font-style: Bold;
+  color: token.$gray700;
+}
+
+.divider {
+  border: none;
+  width: 227px;
+  height: 1px;
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.reactions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 16px 0 20px 24px;
+}
+
+.reaction {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 8px 12px;
+  gap: 2px;
+  background-color: rgba(0, 0, 0, 0.54);
+  color: token.$white;
+  border-radius: 32px;
+  font-size: token.$font-sm;
+  font-weight: 500;
+  height: 32px;
+  width: 65px;
+}

--- a/src/pages/list/CardSlider.jsx
+++ b/src/pages/list/CardSlider.jsx
@@ -1,0 +1,76 @@
+//카드 리스트, 스크롤, 버튼 담당
+import { useEffect, useRef, useState } from "react";
+
+import CardItem from "@/pages/list/CardItem";
+import styles from "@/pages/list/CardSlider.module.scss";
+import SlideButton from "@/pages/list/SlideButton";
+
+function CardSlider({ cards }) {
+  const sliderRef = useRef(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollButtons = () => {
+    const slider = sliderRef.current;
+    if (!slider) return;
+
+    //scrollLeft: 왼쪽으로 얼마나 스크롤 되었는지
+    //scrollWidth: 가능한 총 스크롤 가로 너비
+    //clientWidth: 보이는 영역 너비
+    setCanScrollLeft(slider.scrollLeft > 0);
+    setCanScrollRight(
+      slider.scrollWidth > slider.clientWidth + slider.scrollLeft,
+    );
+  };
+
+  const scrollLeft = () => {
+    sliderRef.current.scrollBy({ left: -300, behavior: "smooth" });
+  };
+
+  const scrollRight = () => {
+    sliderRef.current.scrollBy({ left: 300, behavior: "smooth" });
+  };
+
+  useEffect(() => {
+    updateScrollButtons();
+    const slider = sliderRef.current;
+    if (!slider) return;
+
+    //scroll, resize 발생할 때마다 버튼 갱신
+    slider.addEventListener("scroll", updateScrollButtons);
+    window.addEventListener("resize", updateScrollButtons);
+
+    return () => {
+      slider.removeEventListener("scroll", updateScrollButtons);
+      window.removeEventListener("resize", updateScrollButtons);
+    };
+  }, []);
+
+  const showButtons = cards.length >= 4;
+
+  //카드가 4개 이상이고, 왼쪽 스크롤 가능하면 SlideButton 렌더링
+  return (
+    <div className={styles.sliderWrapper}>
+      {showButtons && canScrollLeft && (
+        <div className={styles.buttonLeft}>
+          <SlideButton direction="left" onClick={scrollLeft} />
+        </div>
+      )}
+      <div className={styles.sliderOuter} ref={sliderRef}>
+        <div className={styles.slider}>
+          {cards.map((card) => (
+            <CardItem key={card.id} {...card} />
+          ))}
+        </div>
+      </div>
+
+      {showButtons && canScrollRight && (
+        <div className={styles.buttonRight}>
+          <SlideButton direction="right" onClick={scrollRight} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default CardSlider;

--- a/src/pages/list/CardSlider.module.scss
+++ b/src/pages/list/CardSlider.module.scss
@@ -1,0 +1,55 @@
+@use "@/styles/token" as token;
+
+.sliderWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-top: token.$size-md;
+  max-width: 1130px;
+  width: 100%;
+  overflow: visible;
+  margin-bottom: 50px;
+}
+
+.sliderOuter {
+  overflow-x: auto;
+  overflow-y: visible;
+  flex: 1;
+  padding: 10px 24px;
+  scroll-padding: 0 24px;
+}
+
+.slider {
+  display: flex;
+  gap: 20px;
+  scroll-behavior: smooth;
+  max-width: 100%;
+  overflow: visible;
+  & > * {
+    flex-shrink: 0;
+    width: 260px;
+  }
+  padding-bottom: 30px;
+  //스크롤바 숨김
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.buttonLeft {
+  position: absolute;
+  top: 50%;
+  left: -20px;
+  transform: translateY(-100%);
+  z-index: 10;
+}
+
+.buttonRight {
+  position: absolute;
+  top: 50%;
+  right: -20px;
+  transform: translateY(-100%);
+  z-index: 10;
+}

--- a/src/pages/list/CardSliderSection.jsx
+++ b/src/pages/list/CardSliderSection.jsx
@@ -1,0 +1,88 @@
+//데이터 CardSlider에 전달, 제목 및 Empty 처리
+import CardSlider from "@/pages/list/CardSlider";
+import styles from "@/pages/list/CardSliderSection.module.scss";
+import EmptyState from "@/pages/list/EmptyState";
+import SectionTitle from "@/pages/list/SectionTitle";
+
+function CardSliderSection({ title }) {
+  //mock 데이터
+  const mockCards = [
+    {
+      id: 1,
+      title: "sowon",
+      backgroundColor: "#FFD700",
+      participants: [
+        "https://via.placeholder.com/24/FFB6C1",
+        "https://via.placeholder.com/24/87CEFA",
+        "https://via.placeholder.com/24/90EE90",
+        "https://via.placeholder.com/24/FFD700",
+      ],
+      totalCount: 5,
+      emojiReaction: [
+        { emoji: "💖", count: 3 },
+        { emoji: "🎉", count: 2 },
+      ],
+    },
+    {
+      id: 2,
+      title: "jiho",
+      backgroundColor: "#ECD9FF",
+      participants: [
+        "https://via.placeholder.com/24/90EE90",
+        "https://via.placeholder.com/24/ADD8E6",
+      ],
+      totalCount: 2,
+      emojiReaction: [
+        { emoji: "👍", count: 1 },
+        { emoji: "💖", count: 1 },
+      ],
+    },
+    {
+      id: 3,
+      title: "haeun",
+      backgroundColor: "#D0F5C3",
+      participants: [
+        "https://via.placeholder.com/24/FFA07A",
+        "https://via.placeholder.com/24/9370DB",
+        "https://via.placeholder.com/24/20B2AA",
+      ],
+      totalCount: 3,
+      emojiReaction: [{ emoji: "🔥", count: 4 }],
+    },
+    {
+      id: 4,
+      title: "nana",
+      backgroundColor: "#E2F5FF",
+      participants: ["https://via.placeholder.com/24/FFC0CB"],
+      totalCount: 1,
+      emojiReaction: [{ emoji: "😊", count: 1 }],
+    },
+    {
+      id: 5,
+      title: "leo",
+      backgroundColor: "#FFE2AD",
+      participants: [
+        "https://via.placeholder.com/24/FFB6C1",
+        "https://via.placeholder.com/24/87CEFA",
+        "https://via.placeholder.com/24/FFA500",
+        "https://via.placeholder.com/24/40E0D0",
+      ],
+      totalCount: 7,
+      emojiReaction: [
+        { emoji: "🎁", count: 2 },
+        { emoji: "💯", count: 3 },
+      ],
+    },
+  ];
+
+  const hasCards = mockCards.length > 0;
+
+  return (
+    <section className={styles.wrapper}>
+      <SectionTitle>{title}</SectionTitle>
+      {hasCards ? <CardSlider cards={mockCards} /> : <EmptyState />}
+    </section>
+  );
+}
+
+export default CardSliderSection;

--- a/src/pages/list/CardSliderSection.module.scss
+++ b/src/pages/list/CardSliderSection.module.scss
@@ -1,0 +1,4 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/pages/list/EmptyState.jsx
+++ b/src/pages/list/EmptyState.jsx
@@ -1,0 +1,8 @@
+function EmptyState() {
+  return (
+    <div style={{ textAlign: "center", padding: "40px 0" }}>
+      <p>아직 롤링페이퍼가 없어요! 🙌</p>
+    </div>
+  );
+}
+export default EmptyState;

--- a/src/pages/list/ListPage.jsx
+++ b/src/pages/list/ListPage.jsx
@@ -1,0 +1,22 @@
+import Header from "@/components/layout/Header";
+import CardSliderSection from "@/pages/list/CardSliderSection";
+import styles from "@/pages/list/ListPage.module.scss";
+
+function ListPage() {
+  return (
+    <>
+      <Header />
+      <div className={styles.wrapper}>
+        <CardSliderSection title="인기 롤링 페이퍼 🔥" />
+        <CardSliderSection title="최근에 만든 롤링 페이퍼 ⭐" />
+
+        {/* 공통 컴포넌트로 처리 */}
+        <div>
+          <button>나도 만들어보기</button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default ListPage;

--- a/src/pages/list/ListPage.module.scss
+++ b/src/pages/list/ListPage.module.scss
@@ -1,0 +1,11 @@
+.wrapper {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 50px;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  overflow: visible;
+}

--- a/src/pages/list/SectionTitle.jsx
+++ b/src/pages/list/SectionTitle.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+function SectionTitle({ children }) {
+  return (
+    <h2 style={{ fontSize: "24px", fontWeight: "700", marginBottom: "16px" }}>
+      {children}
+    </h2>
+  );
+}
+
+export default SectionTitle;

--- a/src/pages/list/SectionTitle.module.scss
+++ b/src/pages/list/SectionTitle.module.scss
@@ -1,0 +1,11 @@
+@use "@/styles/_token" as token;
+@use "@/styles/font" as font;
+
+.title {
+  margin-left: 380px;
+
+  font-size: token.$font-2xl;
+  font-weight: 700;
+  font-family: token.$font-family-primary;
+  color: token.$black;
+}

--- a/src/pages/list/SlideButton.jsx
+++ b/src/pages/list/SlideButton.jsx
@@ -1,0 +1,19 @@
+import styles from "@/pages/list/SlideButton.module.scss";
+
+function SlideButton({ direction, onClick }) {
+  // 화살표 방향 결정
+  const isLeft = direction === "left";
+  const arrow = isLeft ? "<" : ">";
+
+  // 왼쪽 방향이면 styles.left 추가
+  return (
+    <button
+      className={`${styles.button} ${isLeft ? styles.left : styles.right}`}
+      onClick={onClick}
+    >
+      {arrow}
+    </button>
+  );
+}
+
+export default SlideButton;

--- a/src/pages/list/SlideButton.module.scss
+++ b/src/pages/list/SlideButton.module.scss
@@ -1,0 +1,34 @@
+@use "@/styles/token" as token;
+
+.button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+
+  background-color: rgba(255, 255, 255, 0.9);
+  border: 1px solid #dadcdf;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.08);
+
+  color: #101010;
+  font-size: token.$font-md;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  transition:
+    background-color 0.2s ease,
+    transform 0.2s ease,
+    color 0.2s ease;
+
+  &:hover {
+    color: token.$purple500;
+    transform: scale(1.1);
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.3;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## 📎 연관된 Issue

-[List] 리스트 페이지 UI 구성 #13

## 📝작업 내용

- CardItem 컴포넌트 구현 (제목, 참여자, 리액션 표시 등)
- CardSlider 구현 (화면에 4장까지, 버튼 슬라이드 포함)
- 카드 및 버튼 호버 시 효과 적용
- 현재 배경은 mock 데이터 기반으로 backgroundColor 전달
- API 연동 시 실제 배경 정보로 대체 예정
- 공통 컴포넌트 및 토큰 추가 시 대체 예정

### 스크린샷 (선택)
<img width="995" height="766" alt="스크린샷 2025-07-14 오후 12 01 53" src="https://github.com/user-attachments/assets/c17e073c-fe53-4483-9be0-0a13736a0c1c" />
<img width="337" height="326" alt="스크린샷 2025-07-14 오후 12 02 02" src="https://github.com/user-attachments/assets/52046424-142c-41ba-9e42-69f0e0fa05dc" />
<img width="74" height="80" alt="스크린샷 2025-07-14 오후 12 02 15" src="https://github.com/user-attachments/assets/91ec1445-8a79-4613-ac9e-13eda633d07f" />
<img width="901" height="216" alt="스크린샷 2025-07-14 오후 12 02 30" src="https://github.com/user-attachments/assets/58f70eb0-2d43-4c63-b8d4-d7c7f2f2c58c" />



